### PR TITLE
[ Feature/33 ] 피드백 반영 코드 수정, 트랜잭션 설정, save 코드 수정, 클래스의 setter 삭제

### DIFF
--- a/src/main/java/com/mindDiary/mindDiary/config/DatabaseConfiguration.java
+++ b/src/main/java/com/mindDiary/mindDiary/config/DatabaseConfiguration.java
@@ -12,9 +12,13 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
 @PropertySource("classpath:/application.yml")
+@EnableTransactionManagement
 public class DatabaseConfiguration {
 
   @Autowired
@@ -45,5 +49,10 @@ public class DatabaseConfiguration {
   @Bean
   public SqlSessionTemplate sqlSessionTemplate(SqlSessionFactory sqlSessionFactory) {
     return new SqlSessionTemplate(sqlSessionFactory);
+  }
+
+  @Bean
+  public PlatformTransactionManager txManager() {
+    return new DataSourceTransactionManager(dataSource());
   }
 }

--- a/src/main/java/com/mindDiary/mindDiary/controller/DiagnosisController.java
+++ b/src/main/java/com/mindDiary/mindDiary/controller/DiagnosisController.java
@@ -11,7 +11,6 @@ import com.mindDiary.mindDiary.entity.Role;
 import com.mindDiary.mindDiary.entity.UserDiagnosis;
 import com.mindDiary.mindDiary.service.DiagnosisService;
 import com.mindDiary.mindDiary.service.UserDiagnosisService;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
@@ -29,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/diagnosis")
+@RequestMapping("/diagnoses")
 public class DiagnosisController {
 
   private final DiagnosisService diagnosisService;
@@ -37,24 +36,24 @@ public class DiagnosisController {
 
   @GetMapping
   @LoginCheck(checkLevel = Role.USER)
-  public ResponseEntity<List<ReadDiagnosisResponseDTO>> readDiagnosis() {
-    List<Diagnosis> diagnoses = diagnosisService.readDiagnosis();
+  public ResponseEntity<List<ReadDiagnosisResponseDTO>> readDiagnoses() {
+    List<Diagnosis> diagnoses = diagnosisService.readDiagnoses();
     return new ResponseEntity<>(createReadDiagnosisResponses(diagnoses), HttpStatus.OK);
   }
 
-  @GetMapping("/question/{diagnosisId}")
+  @GetMapping("/{diagnosisId}/question")
   @LoginCheck(checkLevel = Role.USER)
   public ResponseEntity<ReadDiagnosisResponseDTO> readDiagnosisQuestions(
       @PathVariable("diagnosisId") @Valid int diagnosisId) {
 
     DiagnosisWithQuestion diagnosisWithQuestion
-        = diagnosisService.readDiagnosisQuestions(diagnosisId);
+        = diagnosisService.readDiagnosisWithQuestions(diagnosisId);
 
     return new ResponseEntity<>(ReadDiagnosisResponseDTO.create(diagnosisWithQuestion),
         HttpStatus.OK);
   }
 
-  @PostMapping("/result/{diagnosisId}")
+  @PostMapping("/{diagnosisId}/result")
   @LoginCheck(checkLevel = Role.USER)
   public ResponseEntity createDiagnosisResult(@PathVariable("diagnosisId") @Valid int diagnosisId,
       @RequestBody @Valid CreateDiagnosisResultRequestDTO createDiagnosisResultRequest,

--- a/src/main/java/com/mindDiary/mindDiary/controller/DiaryController.java
+++ b/src/main/java/com/mindDiary/mindDiary/controller/DiaryController.java
@@ -31,29 +31,31 @@ public class DiaryController {
   @GetMapping
   @LoginCheck(checkLevel = Role.USER)
   public ResponseEntity<List<DiaryResponseDTO>> readDiaries(Integer userId) {
-
+    log.info(String.valueOf(userId));
     List<Diary> diaries = diaryService.readDiaries(userId);
-
-    List<DiaryResponseDTO> diaryResponseDTOS
-        = diaries.stream()
-        .map(diary -> diary.turnIntoDiaryResponseDTO())
-        .collect(Collectors.toList());
-    return new ResponseEntity(diaryResponseDTOS, HttpStatus.OK);
+    return new ResponseEntity(createDiaryResponses(diaries), HttpStatus.OK);
   }
+
 
   @GetMapping("/{diaryId}")
   @LoginCheck(checkLevel = Role.USER)
   public ResponseEntity readOneDiary(@PathVariable("diaryId") @Valid int diaryId) {
     Diary diary = diaryService.readOneDiary(diaryId);
-    DiaryResponseDTO diaryResponseDTO = diary.turnIntoDiaryResponseDTO();
+    DiaryResponseDTO diaryResponseDTO = DiaryResponseDTO.create(diary);
     return new ResponseEntity(diaryResponseDTO, HttpStatus.OK);
   }
 
   @PostMapping
   @LoginCheck(checkLevel = Role.USER)
   public ResponseEntity createDiary(@RequestBody @Valid CreateDiaryRequestDTO createDiaryRequestDTO, Integer userId) {
-    Diary diary = createDiaryRequestDTO.turnIntoDiaryEntity();
-    diaryService.createDiary(diary, userId);
+    Diary diary = createDiaryRequestDTO.createEntity(userId);
+    diaryService.createDiary(diary);
     return new ResponseEntity(HttpStatus.OK);
+  }
+
+  private List<DiaryResponseDTO> createDiaryResponses(List<Diary> diaries) {
+    return diaries.stream()
+        .map(diary -> DiaryResponseDTO.create(diary))
+        .collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/mindDiary/mindDiary/controller/PostController.java
+++ b/src/main/java/com/mindDiary/mindDiary/controller/PostController.java
@@ -2,17 +2,11 @@ package com.mindDiary.mindDiary.controller;
 
 import com.mindDiary.mindDiary.annotation.LoginCheck;
 import com.mindDiary.mindDiary.dto.request.CreatePostRequestDTO;
-import com.mindDiary.mindDiary.dto.response.PostMediaResponseDTO;
 import com.mindDiary.mindDiary.dto.response.ReadPostResponseDTO;
-import com.mindDiary.mindDiary.dto.response.TagResponseDTO;
 import com.mindDiary.mindDiary.entity.Post;
-import com.mindDiary.mindDiary.entity.PostMedia;
 import com.mindDiary.mindDiary.entity.Role;
-import com.mindDiary.mindDiary.entity.Tag;
-import com.mindDiary.mindDiary.repository.TagRepository;
 import com.mindDiary.mindDiary.service.PostLikeHateService;
 import com.mindDiary.mindDiary.service.PostService;
-import com.sun.mail.iap.Response;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
@@ -55,8 +49,9 @@ public class PostController {
   @GetMapping("/{postId}")
   @LoginCheck(checkLevel = Role.USER)
   public ResponseEntity readPost(@PathVariable @Valid int postId) {
+
     Post post = postService.readPost(postId);
-    return new ResponseEntity(createPostResponse(post), HttpStatus.OK);
+    return new ResponseEntity(ReadPostResponseDTO.create(post), HttpStatus.OK);
   }
 
   @PostMapping("/like/{postId}")
@@ -73,50 +68,11 @@ public class PostController {
     return new ResponseEntity(HttpStatus.OK);
   }
 
-
-  private ReadPostResponseDTO createPostResponse(Post post) {
-    ReadPostResponseDTO response = new ReadPostResponseDTO();
-    response.setId(post.getId());
-    response.setWriter(post.getWriter());
-    response.setCreatedAt(post.getCreatedAt());
-    response.setTitle(post.getTitle());
-    response.setContent(post.getContent());
-    response.setVisitCount(post.getVisitCount());
-    response.setLikeCount(post.getLikeCount());
-    response.setHateCount(post.getHateCount());
-    response.setReplyCount(post.getReplyCount());
-
-    List<PostMediaResponseDTO> postMediaResponses = createMediaResponses(post.getPostMedias());
-    List<TagResponseDTO> tagResponses = createTagResponses(post.getTags());
-
-    response.setTags(tagResponses);
-    response.setPostMedias(postMediaResponses);
-    return response;
-  }
-
-  private List<PostMediaResponseDTO> createMediaResponses(List<PostMedia> postMedias) {
-    return postMedias.stream()
-        .map(postMedia -> createMediaResponse(postMedia))
-        .collect(Collectors.toList());
-  }
-
-  private PostMediaResponseDTO createMediaResponse(PostMedia postMedia) {
-    return new PostMediaResponseDTO(postMedia.getType(), postMedia.getUrl());
-  }
-
-  private List<TagResponseDTO> createTagResponses(List<Tag> tags) {
-    return tags.stream()
-        .map(tag -> createTagResponse(tag))
-        .collect(Collectors.toList());
-  }
-
-  private TagResponseDTO createTagResponse(Tag tag) {
-    return new TagResponseDTO(tag.getName());
-  }
-
   private List<ReadPostResponseDTO> createPostResponses(List<Post> posts) {
     return posts.stream()
-        .map(post -> createPostResponse(post))
+        .map(post -> ReadPostResponseDTO.create(post))
         .collect(Collectors.toList());
   }
+
+
 }

--- a/src/main/java/com/mindDiary/mindDiary/controller/PostController.java
+++ b/src/main/java/com/mindDiary/mindDiary/controller/PostController.java
@@ -30,7 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/post")
+@RequestMapping("/posts")
 public class PostController {
 
   private final PostService postService;

--- a/src/main/java/com/mindDiary/mindDiary/controller/ReplyController.java
+++ b/src/main/java/com/mindDiary/mindDiary/controller/ReplyController.java
@@ -47,11 +47,8 @@ public class ReplyController {
 
   private List<ReadReplyResponseDTO> createReplyResponses(List<Reply> replies) {
     return replies.stream()
-        .map(reply -> createReplyResponse(reply))
+        .map(reply -> ReadReplyResponseDTO.create(reply))
         .collect(Collectors.toList());
   }
 
-  private ReadReplyResponseDTO createReplyResponse(Reply reply) {
-    return new ReadReplyResponseDTO(reply.getWriter(), reply.getContent(), reply.getCreatedAt());
-  }
 }

--- a/src/main/java/com/mindDiary/mindDiary/dto/request/CreateDiagnosisResultRequestDTO.java
+++ b/src/main/java/com/mindDiary/mindDiary/dto/request/CreateDiagnosisResultRequestDTO.java
@@ -2,11 +2,13 @@ package com.mindDiary.mindDiary.dto.request;
 
 import java.util.List;
 import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class CreateDiagnosisResultRequestDTO {
 
   @NotNull

--- a/src/main/java/com/mindDiary/mindDiary/dto/request/CreateDiaryRequestDTO.java
+++ b/src/main/java/com/mindDiary/mindDiary/dto/request/CreateDiaryRequestDTO.java
@@ -1,14 +1,18 @@
 package com.mindDiary.mindDiary.dto.request;
 
-import com.mindDiary.mindDiary.entity.FeelingStatus;
 import com.mindDiary.mindDiary.entity.Diary;
+import com.mindDiary.mindDiary.entity.FeelingStatus;
+import java.time.LocalDateTime;
 import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class CreateDiaryRequestDTO {
+
   @NotNull
   private FeelingStatus feelingStatus;
 
@@ -18,7 +22,12 @@ public class CreateDiaryRequestDTO {
   @NotNull
   private String content;
 
-  public Diary turnIntoDiaryEntity() {
-    return Diary.create(title, content, feelingStatus);
+  public Diary createEntity(int userId) {
+    return Diary.create(
+        userId,
+        LocalDateTime.now(),
+        feelingStatus,
+        title,
+        content);
   }
 }

--- a/src/main/java/com/mindDiary/mindDiary/dto/request/CreatePostRequestDTO.java
+++ b/src/main/java/com/mindDiary/mindDiary/dto/request/CreatePostRequestDTO.java
@@ -8,13 +8,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @ToString
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class CreatePostRequestDTO {
 
   @NotNull
@@ -26,24 +28,19 @@ public class CreatePostRequestDTO {
 
   List<TagRequestDTO> tag;
 
-  public Post createEntity(Integer userId) {
-    Post post = new Post();
-    post.setUserId(userId);
-    post.setCreatedAt(LocalDateTime.now());
-    post.setTitle(title);
-    post.setContent(content);
-    post.setVisitCount(0);
-    post.setLikeCount(0);
-    post.setHateCount(0);
-    post.setReplyCount(0);
+  public Post createEntity(int userId) {
 
-    List<PostMedia> medias = addPostMedia();
-    post.addPostMedias(medias);
-
-    List<Tag> tags = addTags();
-    post.addTags(tags);
-
-    return post;
+    return Post.create(
+        userId,
+        LocalDateTime.now(),
+        title,
+        content,
+        0,
+        0,
+        0,
+        0,
+        addPostMedia(),
+        addTags());
   }
 
   private List<Tag> addTags() {

--- a/src/main/java/com/mindDiary/mindDiary/dto/request/CreateReplyRequestDTO.java
+++ b/src/main/java/com/mindDiary/mindDiary/dto/request/CreateReplyRequestDTO.java
@@ -3,21 +3,24 @@ package com.mindDiary.mindDiary.dto.request;
 import com.mindDiary.mindDiary.entity.Reply;
 import java.time.LocalDateTime;
 import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class CreateReplyRequestDTO {
+
   @NotNull
   private String content;
 
   public Reply createEntity(int userId, int postId) {
-    Reply reply = new Reply();
-    reply.setUserId(userId);
-    reply.setPostId(postId);
-    reply.setContent(content);
-    reply.setCreatedAt(LocalDateTime.now());
-    return reply;
+
+    return Reply.create(
+        userId,
+        postId,
+        content,
+        LocalDateTime.now());
   }
 }

--- a/src/main/java/com/mindDiary/mindDiary/dto/request/JoinUserRequestDTO.java
+++ b/src/main/java/com/mindDiary/mindDiary/dto/request/JoinUserRequestDTO.java
@@ -1,15 +1,19 @@
 package com.mindDiary.mindDiary.dto.request;
 
+import com.mindDiary.mindDiary.entity.Role;
 import com.mindDiary.mindDiary.entity.User;
+import java.util.UUID;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @ToString
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class JoinUserRequestDTO {
 
   @Email
@@ -22,6 +26,11 @@ public class JoinUserRequestDTO {
   private String password;
 
   public User createEntity() {
-    return User.create(email, nickname, password);
+    return User.create(
+        email,
+        nickname,
+        password,
+        Role.NOT_PERMITTED,
+        UUID.randomUUID().toString());
   }
 }

--- a/src/main/java/com/mindDiary/mindDiary/dto/request/LoginUserRequestDTO.java
+++ b/src/main/java/com/mindDiary/mindDiary/dto/request/LoginUserRequestDTO.java
@@ -2,11 +2,15 @@ package com.mindDiary.mindDiary.dto.request;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
+@ToString
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class LoginUserRequestDTO {
 
   @Email

--- a/src/main/java/com/mindDiary/mindDiary/dto/request/MediaRequestDTO.java
+++ b/src/main/java/com/mindDiary/mindDiary/dto/request/MediaRequestDTO.java
@@ -1,14 +1,17 @@
 package com.mindDiary.mindDiary.dto.request;
 
 import com.mindDiary.mindDiary.entity.Type;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @ToString
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class MediaRequestDTO {
+
   private Type type;
   private String url;
 

--- a/src/main/java/com/mindDiary/mindDiary/dto/request/QuestionAnswerRequestDTO.java
+++ b/src/main/java/com/mindDiary/mindDiary/dto/request/QuestionAnswerRequestDTO.java
@@ -2,14 +2,17 @@ package com.mindDiary.mindDiary.dto.request;
 
 import com.mindDiary.mindDiary.entity.Reverse;
 import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @ToString
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class QuestionAnswerRequestDTO {
+
   @NotNull
   private int questionId;
   @NotNull

--- a/src/main/java/com/mindDiary/mindDiary/dto/request/TagRequestDTO.java
+++ b/src/main/java/com/mindDiary/mindDiary/dto/request/TagRequestDTO.java
@@ -1,12 +1,14 @@
 package com.mindDiary.mindDiary.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @ToString
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class TagRequestDTO {
 
   private String name;

--- a/src/main/java/com/mindDiary/mindDiary/dto/response/AccessTokenResponseDTO.java
+++ b/src/main/java/com/mindDiary/mindDiary/dto/response/AccessTokenResponseDTO.java
@@ -1,16 +1,18 @@
 package com.mindDiary.mindDiary.dto.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class AccessTokenResponseDTO {
+
   String accessToken;
 
   public static AccessTokenResponseDTO create(String accessToken) {
-    AccessTokenResponseDTO accessTokenResponseDTO = new AccessTokenResponseDTO();
-    accessTokenResponseDTO.setAccessToken(accessToken);
-    return accessTokenResponseDTO;
+
+    return new AccessTokenResponseDTO(accessToken);
   }
 }

--- a/src/main/java/com/mindDiary/mindDiary/dto/response/DiaryResponseDTO.java
+++ b/src/main/java/com/mindDiary/mindDiary/dto/response/DiaryResponseDTO.java
@@ -1,12 +1,15 @@
 package com.mindDiary.mindDiary.dto.response;
 
+import com.mindDiary.mindDiary.entity.Diary;
 import com.mindDiary.mindDiary.entity.FeelingStatus;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class DiaryResponseDTO {
 
   private int id;
@@ -19,13 +22,12 @@ public class DiaryResponseDTO {
 
   private String content;
 
-  public static DiaryResponseDTO create(int id, LocalDateTime createdAt, FeelingStatus feelingStatus, String title, String content) {
-    DiaryResponseDTO diaryResponseDTO = new DiaryResponseDTO();
-    diaryResponseDTO.setId(id);
-    diaryResponseDTO.setCreatedAt(createdAt);
-    diaryResponseDTO.setFeelingStatus(feelingStatus);
-    diaryResponseDTO.setTitle(title);
-    diaryResponseDTO.setContent(content);
-    return diaryResponseDTO;
+  public static DiaryResponseDTO create(Diary diary) {
+    return new DiaryResponseDTO(
+        diary.getId(),
+        diary.getCreatedAt(),
+        diary.getFeelingStatus(),
+        diary.getTitle(),
+        diary.getContent());
   }
 }

--- a/src/main/java/com/mindDiary/mindDiary/dto/response/ErrorResponseDTO.java
+++ b/src/main/java/com/mindDiary/mindDiary/dto/response/ErrorResponseDTO.java
@@ -1,26 +1,26 @@
 package com.mindDiary.mindDiary.dto.response;
 
 import com.mindDiary.mindDiary.exception.ErrorCode;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class ErrorResponseDTO {
   private int status;
   private String message;
 
   public static ErrorResponseDTO of(ErrorCode errorCode) {
-    ErrorResponseDTO errorResponseDTO = new ErrorResponseDTO();
-    errorResponseDTO.setStatus(errorCode.getStatus());
-    errorResponseDTO.setMessage(errorCode.getMessage());
-    return errorResponseDTO;
+
+    return new ErrorResponseDTO(
+        errorCode.getStatus(),
+        errorCode.getMessage());
   }
 
   public static ErrorResponseDTO of(int status, String message) {
-    ErrorResponseDTO errorResponseDTO = new ErrorResponseDTO();
-    errorResponseDTO.setStatus(status);
-    errorResponseDTO.setMessage(message);
-    return errorResponseDTO;
+
+    return new ErrorResponseDTO(status, message);
   }
 }

--- a/src/main/java/com/mindDiary/mindDiary/dto/response/PostMediaResponseDTO.java
+++ b/src/main/java/com/mindDiary/mindDiary/dto/response/PostMediaResponseDTO.java
@@ -1,15 +1,21 @@
 package com.mindDiary.mindDiary.dto.response;
 
+import com.mindDiary.mindDiary.entity.PostMedia;
 import com.mindDiary.mindDiary.entity.Type;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
 @AllArgsConstructor
+@NoArgsConstructor
 public class PostMediaResponseDTO {
   private Type type;
   private String url;
 
+  public static PostMediaResponseDTO create(PostMedia postMedia) {
+    return new PostMediaResponseDTO(
+        postMedia.getType(),
+        postMedia.getUrl());
+  }
 }

--- a/src/main/java/com/mindDiary/mindDiary/dto/response/ReadDiagnosisResponseDTO.java
+++ b/src/main/java/com/mindDiary/mindDiary/dto/response/ReadDiagnosisResponseDTO.java
@@ -7,10 +7,10 @@ import com.mindDiary.mindDiary.entity.QuestionBaseLine;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
-@Setter
 @Getter
+@NoArgsConstructor
 public class ReadDiagnosisResponseDTO {
 
   private int id;
@@ -19,29 +19,58 @@ public class ReadDiagnosisResponseDTO {
   private List<QuestionBaseLine> questionBaseLines;
   private List<Question> questions;
 
-  public ReadDiagnosisResponseDTO() {
-    questionBaseLines = new ArrayList<>();
-    questions = new ArrayList<>();
+  public ReadDiagnosisResponseDTO(int id, String name, int numberOfChoice) {
+    this.id = id;
+    this.name = name;
+    this.numberOfChoice = numberOfChoice;
+    this.questionBaseLines = new ArrayList<>();
+    this.questions = new ArrayList<>();
+  }
+
+  public ReadDiagnosisResponseDTO(int id, String name, int numberOfChoice,
+      List<Question> questions,
+      List<QuestionBaseLine> questionBaseLines) {
+    this.id = id;
+    this.name = name;
+    this.numberOfChoice = numberOfChoice;
+//    this.questions.addAll(questions);
+    //this.questionBaseLines.addAll(questionBaseLines);
+    this.questions = new ArrayList<>(questions);
+    this.questionBaseLines = new ArrayList<>(questionBaseLines);
   }
 
   public static ReadDiagnosisResponseDTO create(Diagnosis diagnosis) {
+    /*
     ReadDiagnosisResponseDTO readDiagnosisResponse = new ReadDiagnosisResponseDTO();
     readDiagnosisResponse.setId(diagnosis.getId());
     readDiagnosisResponse.setName(diagnosis.getName());
     readDiagnosisResponse.setNumberOfChoice(diagnosis.getNumberOfChoice());
-    return readDiagnosisResponse;
+    */
+    return new ReadDiagnosisResponseDTO(
+        diagnosis.getId(),
+        diagnosis.getName(),
+        diagnosis.getNumberOfChoice());
   }
 
   public static ReadDiagnosisResponseDTO create(DiagnosisWithQuestion diagnosisWithQuestion) {
+    /*
     ReadDiagnosisResponseDTO readDiagnosisResponse = new ReadDiagnosisResponseDTO();
     readDiagnosisResponse.setId(diagnosisWithQuestion.getId());
     readDiagnosisResponse.setName(diagnosisWithQuestion.getName());
     readDiagnosisResponse.setNumberOfChoice(diagnosisWithQuestion.getNumberOfChoice());
     readDiagnosisResponse.addAllQuestions(diagnosisWithQuestion.getQuestions());
     readDiagnosisResponse.addAllQuestionBaseLines(diagnosisWithQuestion.getQuestionBaseLines());
-    return readDiagnosisResponse;
+     */
+
+    return new ReadDiagnosisResponseDTO(
+        diagnosisWithQuestion.getId(),
+        diagnosisWithQuestion.getName(),
+        diagnosisWithQuestion.getNumberOfChoice(),
+        diagnosisWithQuestion.getQuestions(),
+        diagnosisWithQuestion.getQuestionBaseLines());
   }
 
+  /*
   private void addAllQuestions(List<Question> questionList) {
     questions.addAll(questionList);
   }
@@ -49,5 +78,5 @@ public class ReadDiagnosisResponseDTO {
   private void addAllQuestionBaseLines(List<QuestionBaseLine> questionBaseLineList) {
     questionBaseLines.addAll(questionBaseLineList);
   }
-
+*/
 }

--- a/src/main/java/com/mindDiary/mindDiary/dto/response/ReadDiagnosisResultResponseDTO.java
+++ b/src/main/java/com/mindDiary/mindDiary/dto/response/ReadDiagnosisResultResponseDTO.java
@@ -2,13 +2,15 @@ package com.mindDiary.mindDiary.dto.response;
 
 import com.mindDiary.mindDiary.entity.UserDiagnosis;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @ToString
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class ReadDiagnosisResultResponseDTO {
 
   private int diagnosisId;
@@ -17,11 +19,11 @@ public class ReadDiagnosisResultResponseDTO {
   private String content;
 
   public static ReadDiagnosisResultResponseDTO create(UserDiagnosis userDiagnosis) {
-    ReadDiagnosisResultResponseDTO diagnosisResultScoreResponse = new ReadDiagnosisResultResponseDTO();
-    diagnosisResultScoreResponse.setScore(userDiagnosis.getScore());
-    diagnosisResultScoreResponse.setCreatedAt(userDiagnosis.getCreatedAt());
-    diagnosisResultScoreResponse.setContent(userDiagnosis.getContent());
-    diagnosisResultScoreResponse.setDiagnosisId(userDiagnosis.getDiagnosisId());
-    return diagnosisResultScoreResponse;
+
+    return new ReadDiagnosisResultResponseDTO(
+        userDiagnosis.getDiagnosisId(),
+        userDiagnosis.getScore(),
+        userDiagnosis.getCreatedAt(),
+        userDiagnosis.getContent());
   }
 }

--- a/src/main/java/com/mindDiary/mindDiary/dto/response/ReadPostResponseDTO.java
+++ b/src/main/java/com/mindDiary/mindDiary/dto/response/ReadPostResponseDTO.java
@@ -1,12 +1,17 @@
 package com.mindDiary.mindDiary.dto.response;
 
+import com.mindDiary.mindDiary.entity.Post;
+import com.mindDiary.mindDiary.entity.PostMedia;
+import com.mindDiary.mindDiary.entity.Tag;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@NoArgsConstructor
 public class ReadPostResponseDTO {
   private int id;
   private String writer;
@@ -19,4 +24,41 @@ public class ReadPostResponseDTO {
   private int replyCount;
   private List<PostMediaResponseDTO> postMedias;
   private List<TagResponseDTO> tags;
+
+  public ReadPostResponseDTO(int id, String writer, LocalDateTime createdAt, String title, String content,
+      int visitCount, int likeCount, int hateCount, int replyCount,
+      List<PostMedia> postMedias, List<Tag> tags) {
+    this.id = id;
+    this.writer = writer;
+    this.createdAt = createdAt;
+    this.title = title;
+    this.content = content;
+    this.visitCount = visitCount;
+    this.likeCount = likeCount;
+    this.hateCount = hateCount;
+    this.replyCount = replyCount;
+    this.postMedias = postMedias.stream()
+        .map(postMedia -> PostMediaResponseDTO.create(postMedia))
+        .collect(Collectors.toList());
+
+    this.tags = tags.stream()
+        .map(tag -> TagResponseDTO.create(tag))
+        .collect(Collectors.toList());
+
+  }
+
+  public static ReadPostResponseDTO create(Post post) {
+    return new ReadPostResponseDTO(
+        post.getId(),
+        post.getWriter(),
+        post.getCreatedAt(),
+        post.getTitle(),
+        post.getContent(),
+        post.getVisitCount(),
+        post.getLikeCount(),
+        post.getHateCount(),
+        post.getReplyCount(),
+        post.getPostMedias(),
+        post.getTags());
+  }
 }

--- a/src/main/java/com/mindDiary/mindDiary/dto/response/ReadReplyResponseDTO.java
+++ b/src/main/java/com/mindDiary/mindDiary/dto/response/ReadReplyResponseDTO.java
@@ -1,15 +1,23 @@
 package com.mindDiary.mindDiary.dto.response;
 
+import com.mindDiary.mindDiary.entity.Reply;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
 @AllArgsConstructor
+@NoArgsConstructor
 public class ReadReplyResponseDTO {
   private String writer;
   private String content;
   private LocalDateTime createdAt;
+
+  public static ReadReplyResponseDTO create(Reply reply) {
+    return new ReadReplyResponseDTO(
+        reply.getWriter(),
+        reply.getContent(),
+        reply.getCreatedAt());
+  }
 }

--- a/src/main/java/com/mindDiary/mindDiary/dto/response/TagResponseDTO.java
+++ b/src/main/java/com/mindDiary/mindDiary/dto/response/TagResponseDTO.java
@@ -1,12 +1,17 @@
 package com.mindDiary.mindDiary.dto.response;
 
+import com.mindDiary.mindDiary.entity.Tag;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
 @AllArgsConstructor
+@NoArgsConstructor
 public class TagResponseDTO {
   private String name;
+
+  public static TagResponseDTO create(Tag tag) {
+    return new TagResponseDTO(tag.getName());
+  }
 }

--- a/src/main/java/com/mindDiary/mindDiary/entity/Answer.java
+++ b/src/main/java/com/mindDiary/mindDiary/entity/Answer.java
@@ -2,12 +2,13 @@ package com.mindDiary.mindDiary.entity;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
 @AllArgsConstructor
+@NoArgsConstructor
 public class Answer {
+
   private int questionId;
   private int choiceNumber;
   private Reverse reverse;

--- a/src/main/java/com/mindDiary/mindDiary/entity/Diagnosis.java
+++ b/src/main/java/com/mindDiary/mindDiary/entity/Diagnosis.java
@@ -1,10 +1,12 @@
 package com.mindDiary.mindDiary.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Diagnosis {
 
   private int id;

--- a/src/main/java/com/mindDiary/mindDiary/entity/DiagnosisScore.java
+++ b/src/main/java/com/mindDiary/mindDiary/entity/DiagnosisScore.java
@@ -1,11 +1,14 @@
 package com.mindDiary.mindDiary.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class DiagnosisScore {
+
   private int id;
   private int minValue;
   private int maxValue;

--- a/src/main/java/com/mindDiary/mindDiary/entity/DiagnosisWithQuestion.java
+++ b/src/main/java/com/mindDiary/mindDiary/entity/DiagnosisWithQuestion.java
@@ -1,12 +1,20 @@
 package com.mindDiary.mindDiary.entity;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
+
 
 @Getter
-@Setter
-public class DiagnosisWithQuestion extends Diagnosis {
+@AllArgsConstructor
+@NoArgsConstructor
+public class DiagnosisWithQuestion {
+
+  private int id;
+  private String name;
+  private int numberOfChoice;
   private List<Question> questions;
   private List<QuestionBaseLine> questionBaseLines;
+
 }

--- a/src/main/java/com/mindDiary/mindDiary/entity/Diary.java
+++ b/src/main/java/com/mindDiary/mindDiary/entity/Diary.java
@@ -1,12 +1,13 @@
 package com.mindDiary.mindDiary.entity;
 
-import com.mindDiary.mindDiary.dto.response.DiaryResponseDTO;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Diary {
 
   private int id;
@@ -21,16 +22,32 @@ public class Diary {
 
   private String content;
 
-  public static Diary create(String title, String content, FeelingStatus feelingStatus) {
-    Diary diary = new Diary();
-    diary.setTitle(title);
-    diary.setContent(content);
-    diary.setFeelingStatus(feelingStatus);
-    return diary;
+  public Diary(int id, int userId, LocalDateTime createdAt, FeelingStatus feelingStatus, String title) {
+    this.id = id;
+    this.userId = userId;
+    this.createdAt = createdAt;
+    this.feelingStatus = feelingStatus;
+    this.title = title;
   }
 
-  public DiaryResponseDTO turnIntoDiaryResponseDTO() {
-    return DiaryResponseDTO.create(id, createdAt, feelingStatus, title, content);
+
+  public Diary(int userId, LocalDateTime createdAt, FeelingStatus feelingStatus,  String title, String content) {
+    this.userId = userId;
+    this.createdAt = createdAt;
+    this.feelingStatus = feelingStatus;
+    this.title = title;
+    this.content = content;
+
+  }
+
+  public static Diary create(int userId, LocalDateTime createdAt, FeelingStatus feelingStatus,  String title, String content) {
+    return new Diary(
+        userId,
+        createdAt,
+        feelingStatus,
+        title,
+        content
+    );
   }
 
 }

--- a/src/main/java/com/mindDiary/mindDiary/entity/PageCriteria.java
+++ b/src/main/java/com/mindDiary/mindDiary/entity/PageCriteria.java
@@ -1,19 +1,22 @@
 package com.mindDiary.mindDiary.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class PageCriteria {
 
-  private final int perPageNum = 5;
+  private int perPageNum;
   private int pageNumber;
   private int pageStart;
 
-  public PageCriteria(int pageNumber) {
+  public PageCriteria(int pageNumber, int perPageNum) {
     this.pageNumber = pageNumber;
     this.pageStart = calcPageStart(pageNumber);
+    this.perPageNum = perPageNum;
   }
 
   private int calcPageStart(int pageNumber) {

--- a/src/main/java/com/mindDiary/mindDiary/entity/Post.java
+++ b/src/main/java/com/mindDiary/mindDiary/entity/Post.java
@@ -1,17 +1,17 @@
 package com.mindDiary.mindDiary.entity;
 
-import com.mindDiary.mindDiary.dto.request.MediaRequestDTO;
-import com.mindDiary.mindDiary.dto.request.TagRequestDTO;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @ToString
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Post {
 
   private int id;
@@ -27,11 +27,38 @@ public class Post {
   private List<PostMedia> postMedias;
   private List<Tag> tags;
 
-  public void addPostMedias(List<PostMedia> medias) {
-    this.postMedias = new ArrayList<>(medias);
-  }
+  public Post(int userId, LocalDateTime createdAt, String title, String content,
+      int visitCount, int likeCount, int hateCount, int replyCount,
+      List<PostMedia> postMedias, List<Tag> tags) {
 
-  public void addTags(List<Tag> tags) {
+    this.userId = userId;
+    this.createdAt = createdAt;
+    this.title = title;
+    this.content = content;
+    this.visitCount = visitCount;
+    this.likeCount = likeCount;
+    this.hateCount = hateCount;
+    this.replyCount = replyCount;
+    this.postMedias = new ArrayList<>(postMedias);
     this.tags = new ArrayList<>(tags);
   }
+
+  public static Post create(int userId, LocalDateTime createdAt, String title, String content,
+      int visitCount, int likeCount, int hateCount, int replyCount,
+      List<PostMedia> postMedias, List<Tag> tags) {
+
+    return new Post(
+        userId,
+        createdAt,
+        title,
+        content,
+        visitCount,
+        likeCount,
+        hateCount,
+        replyCount,
+        postMedias,
+        tags);
+  }
+
 }
+

--- a/src/main/java/com/mindDiary/mindDiary/entity/PostMedia.java
+++ b/src/main/java/com/mindDiary/mindDiary/entity/PostMedia.java
@@ -1,24 +1,39 @@
 package com.mindDiary.mindDiary.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @ToString
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class PostMedia {
 
   private int id;
-  private int postId;
   private Type type;
   private String url;
+  private int postId;
 
+  public PostMedia(int id, Type type, String url) {
+    this.id = id;
+    this.type = type;
+    this.url = url;
+  }
+  public PostMedia(Type type, String url) {
+    this.type = type;
+    this.url = url;
+  }
+
+  public PostMedia(Type type, String url, int postId) {
+    this.postId = postId;
+    this.type = type;
+    this.url = url;
+  }
 
   public static PostMedia create(Type type, String url) {
-    PostMedia postMedia = new PostMedia();
-    postMedia.setType(type);
-    postMedia.setUrl(url);
-    return postMedia;
+    return new PostMedia(type, url);
   }
+
 }

--- a/src/main/java/com/mindDiary/mindDiary/entity/PostTag.java
+++ b/src/main/java/com/mindDiary/mindDiary/entity/PostTag.java
@@ -1,0 +1,18 @@
+package com.mindDiary.mindDiary.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Setter
+@AllArgsConstructor
+public class PostTag {
+
+  private int postId;
+
+  private int tagId;
+
+}

--- a/src/main/java/com/mindDiary/mindDiary/entity/PostTag.java
+++ b/src/main/java/com/mindDiary/mindDiary/entity/PostTag.java
@@ -2,13 +2,13 @@ package com.mindDiary.mindDiary.entity;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @ToString
 @Getter
-@Setter
 @AllArgsConstructor
+@NoArgsConstructor
 public class PostTag {
 
   private int postId;

--- a/src/main/java/com/mindDiary/mindDiary/entity/Question.java
+++ b/src/main/java/com/mindDiary/mindDiary/entity/Question.java
@@ -1,10 +1,12 @@
 package com.mindDiary.mindDiary.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Question {
 
   private int id;

--- a/src/main/java/com/mindDiary/mindDiary/entity/QuestionBaseLine.java
+++ b/src/main/java/com/mindDiary/mindDiary/entity/QuestionBaseLine.java
@@ -1,10 +1,12 @@
 package com.mindDiary.mindDiary.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class QuestionBaseLine {
 
   private int id;

--- a/src/main/java/com/mindDiary/mindDiary/entity/Reply.java
+++ b/src/main/java/com/mindDiary/mindDiary/entity/Reply.java
@@ -1,11 +1,13 @@
 package com.mindDiary.mindDiary.entity;
 
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Reply {
 
   private int id;
@@ -14,4 +16,19 @@ public class Reply {
   private String content;
   private LocalDateTime createdAt;
   private String writer;
+
+  public Reply(int userId, int postId, String content, LocalDateTime createdAt) {
+    this.userId = userId;
+    this.postId = postId;
+    this.content = content;
+    this.createdAt = createdAt;
+  }
+
+  public static Reply create(int userId, int postId, String content, LocalDateTime createdAt) {
+    return new Reply(
+        userId,
+        postId,
+        content,
+        createdAt);
+  }
 }

--- a/src/main/java/com/mindDiary/mindDiary/entity/Tag.java
+++ b/src/main/java/com/mindDiary/mindDiary/entity/Tag.java
@@ -1,19 +1,24 @@
 package com.mindDiary.mindDiary.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @ToString
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Tag {
   private int id;
   private String name;
 
+  public Tag(String name) {
+    this.name = name;
+  }
+
   public static Tag create(String name) {
-    Tag tag = new Tag();
-    tag.setName(name);
-    return tag;
+
+    return new Tag(name);
   }
 }

--- a/src/main/java/com/mindDiary/mindDiary/entity/Token.java
+++ b/src/main/java/com/mindDiary/mindDiary/entity/Token.java
@@ -3,11 +3,13 @@ package com.mindDiary.mindDiary.entity;
 import com.mindDiary.mindDiary.strategy.cookie.CookieStrategy;
 import com.mindDiary.mindDiary.strategy.jwt.TokenStrategy;
 import javax.servlet.http.Cookie;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Token {
 
   private String accessToken;
@@ -15,10 +17,10 @@ public class Token {
   private String refreshToken;
 
   public static Token create(User user, TokenStrategy tokenStrategy) {
-    Token token = new Token();
-    token.setAccessToken(user.turnUserinfoToAccessToken(tokenStrategy));
-    token.setRefreshToken(user.turnUserinfoToRefreshToken(tokenStrategy));
-    return token;
+
+    return new Token(
+        user.turnUserinfoToAccessToken(tokenStrategy),
+        user.turnUserinfoToRefreshToken(tokenStrategy));
   }
 
   public Cookie turnRefreshTokenInfoCookie(CookieStrategy cookieStrategy) {

--- a/src/main/java/com/mindDiary/mindDiary/entity/User.java
+++ b/src/main/java/com/mindDiary/mindDiary/entity/User.java
@@ -1,15 +1,16 @@
 package com.mindDiary.mindDiary.entity;
 
 import com.mindDiary.mindDiary.strategy.jwt.TokenStrategy;
-import java.util.UUID;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ToString
-@Setter
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class User {
 
   private int id;
@@ -24,6 +25,22 @@ public class User {
 
   private String emailCheckToken;
 
+  public User(int id, String email, String nickname, String password, Role role) {
+    this.id = id;
+    this.email = email;
+    this.nickname = nickname;
+    this.password = password;
+    this.role = role;
+  }
+
+  public User(String email, String nickname, String password, Role role, String emailCheckToken) {
+    this.email = email;
+    this.nickname = nickname;
+    this.password = password;
+    this.role = role;
+    this.emailCheckToken = emailCheckToken;
+  }
+
   public void changeHashedPassword(PasswordEncoder passwordEncoder) {
     this.password = passwordEncoder.encode(password);
   }
@@ -32,14 +49,14 @@ public class User {
     this.role = Role.USER;
   }
 
-  public static User create(String email, String nickname, String password) {
-    User user = new User();
-    user.setEmail(email);
-    user.setNickname(nickname);
-    user.setPassword(password);
-    user.setRole(Role.NOT_PERMITTED);
-    user.setEmailCheckToken(UUID.randomUUID().toString());
-    return user;
+  public static User create(String email, String nickname, String password, Role role, String emailCheckToken) {
+
+    return new User(
+        email,
+        nickname,
+        password,
+        role,
+        emailCheckToken);
   }
 
   public String turnUserinfoToAccessToken(TokenStrategy tokenStrategy) {

--- a/src/main/java/com/mindDiary/mindDiary/entity/UserDiagnosis.java
+++ b/src/main/java/com/mindDiary/mindDiary/entity/UserDiagnosis.java
@@ -1,11 +1,13 @@
 package com.mindDiary.mindDiary.entity;
 
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class UserDiagnosis {
 
   private int userId;
@@ -14,13 +16,14 @@ public class UserDiagnosis {
   private LocalDateTime createdAt;
   private String content;
 
-  public static UserDiagnosis create(int userId, int diagnosisId, LocalDateTime createdAt, int score, String content) {
-    UserDiagnosis userDiagnosis = new UserDiagnosis();
-    userDiagnosis.setUserId(userId);
-    userDiagnosis.setDiagnosisId(diagnosisId);
-    userDiagnosis.setCreatedAt(createdAt);
-    userDiagnosis.setScore(score);
-    userDiagnosis.setContent(content);
-    return userDiagnosis;
+
+  public static UserDiagnosis create(int userId, int diagnosisId, int score, LocalDateTime createdAt,  String content) {
+
+    return new UserDiagnosis(
+        userId,
+        diagnosisId,
+        score,
+        createdAt,
+        content);
   }
 }

--- a/src/main/java/com/mindDiary/mindDiary/repository/DiagnosisRepository.java
+++ b/src/main/java/com/mindDiary/mindDiary/repository/DiagnosisRepository.java
@@ -8,7 +8,7 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface DiagnosisRepository {
 
-  List<Diagnosis> findDiagnosis();
+  List<Diagnosis> findDiagnoses();
 
   DiagnosisWithQuestion findDiagnosisWithQuestionById(int diagnosisId);
 

--- a/src/main/java/com/mindDiary/mindDiary/repository/PostTagRepository.java
+++ b/src/main/java/com/mindDiary/mindDiary/repository/PostTagRepository.java
@@ -1,9 +1,11 @@
 package com.mindDiary.mindDiary.repository;
 
+import com.mindDiary.mindDiary.entity.PostTag;
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface PostTagRepository {
 
-  int save(int postId, int tagId);
+  int save(List<PostTag> postTags);
 }

--- a/src/main/java/com/mindDiary/mindDiary/repository/TagRepository.java
+++ b/src/main/java/com/mindDiary/mindDiary/repository/TagRepository.java
@@ -1,12 +1,13 @@
 package com.mindDiary.mindDiary.repository;
 
 import com.mindDiary.mindDiary.entity.Tag;
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface TagRepository {
 
-  int save(Tag tag);
-
   Tag findByName(String name);
+
+  int save(List<Tag> tags);
 }

--- a/src/main/java/com/mindDiary/mindDiary/service/DiagnosisService.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/DiagnosisService.java
@@ -8,9 +8,9 @@ import java.util.List;
 
 public interface DiagnosisService {
 
-  List<Diagnosis> readDiagnosis();
+  List<Diagnosis> readDiagnoses();
 
-  DiagnosisWithQuestion readDiagnosisQuestions(int diagnosisId);
+  DiagnosisWithQuestion readDiagnosisWithQuestions(int diagnosisId);
 
   UserDiagnosis createDiagnosisResult(int diagnosisId, List<Answer> answers, int userId);
 

--- a/src/main/java/com/mindDiary/mindDiary/service/DiagnosisServiceImpl.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/DiagnosisServiceImpl.java
@@ -46,7 +46,7 @@ public class DiagnosisServiceImpl implements DiagnosisService {
     DiagnosisScore diagnosisScore = diagnosisScoreService.readOneByDiagnosisIdAndScore(diagnosisId, score);
 
     UserDiagnosis userDiagnosis = UserDiagnosis
-        .create(userId, diagnosisId, LocalDateTime.now(), score, diagnosisScore.getContent());
+        .create(userId, diagnosisId, score, LocalDateTime.now(), diagnosisScore.getContent());
 
     userDiagnosisService.save(userDiagnosis);
 

--- a/src/main/java/com/mindDiary/mindDiary/service/DiagnosisServiceImpl.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/DiagnosisServiceImpl.java
@@ -27,12 +27,12 @@ public class DiagnosisServiceImpl implements DiagnosisService {
   private final ScoreCalculateStrategy scoreCalculateStrategy;
 
   @Override
-  public List<Diagnosis> readDiagnosis() {
-    return diagnosisRepository.findDiagnosis();
+  public List<Diagnosis> readDiagnoses() {
+    return diagnosisRepository.findDiagnoses();
   }
 
   @Override
-  public DiagnosisWithQuestion readDiagnosisQuestions(int diagnosisId) {
+  public DiagnosisWithQuestion readDiagnosisWithQuestions(int diagnosisId) {
     return diagnosisRepository.findDiagnosisWithQuestionById(diagnosisId);
   }
 
@@ -47,6 +47,7 @@ public class DiagnosisServiceImpl implements DiagnosisService {
 
     UserDiagnosis userDiagnosis = UserDiagnosis
         .create(userId, diagnosisId, LocalDateTime.now(), score, diagnosisScore.getContent());
+
     userDiagnosisService.save(userDiagnosis);
 
     return userDiagnosis;
@@ -59,6 +60,7 @@ public class DiagnosisServiceImpl implements DiagnosisService {
   }
 
   public int calc(List<Answer> answers, int diagnosisId) {
+
     List<QuestionBaseLine> questionBaseLines = questionBaseLineService.readByDiagnosisId(diagnosisId);
     scoreCalculateStrategy.addScoreBaseLine(createIntegerBaseLine(questionBaseLines));
 

--- a/src/main/java/com/mindDiary/mindDiary/service/DiaryService.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/DiaryService.java
@@ -9,5 +9,5 @@ public interface DiaryService {
 
   Diary readOneDiary(int userId);
 
-  void createDiary(Diary diary, int userId);
+  void createDiary(Diary diary);
 }

--- a/src/main/java/com/mindDiary/mindDiary/service/DiaryServiceImpl.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/DiaryServiceImpl.java
@@ -2,7 +2,6 @@ package com.mindDiary.mindDiary.service;
 
 import com.mindDiary.mindDiary.entity.Diary;
 import com.mindDiary.mindDiary.repository.DiaryRepository;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,9 +25,7 @@ public class DiaryServiceImpl implements DiaryService {
   }
 
   @Override
-  public void createDiary(Diary diary, int userId) {
-    diary.setUserId(userId);
-    diary.setCreatedAt(LocalDateTime.now());
+  public void createDiary(Diary diary) {
     diaryRepository.save(diary);
   }
 }

--- a/src/main/java/com/mindDiary/mindDiary/service/PostServiceImpl.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/PostServiceImpl.java
@@ -26,14 +26,17 @@ public class PostServiceImpl implements PostService {
   public void createPost(Post post) {
     postRepository.save(post);
 
+    tagService.save(post.getTags());
+
     createPostTags(post.getTags(), post.getId());
+
     createPostMedias(post.getPostMedias(), post.getId());
 
   }
 
   @Override
   public List<Post> readHotPosts(int pageNumber) {
-    PageCriteria pageCriteria = new PageCriteria(pageNumber);
+    PageCriteria pageCriteria = new PageCriteria(pageNumber, 5);
     return postRepository.findHotPosts(pageCriteria);
   }
 
@@ -44,8 +47,6 @@ public class PostServiceImpl implements PostService {
   }
 
   private void createPostTags(List<Tag> tags, int postId) {
-
-    tagService.save(tags);
 
     List<PostTag> postTags = tags.stream()
         .map(tag -> new PostTag(postId, tag.getId()))
@@ -60,7 +61,11 @@ public class PostServiceImpl implements PostService {
     if (postMedias.isEmpty()) {
       return;
     }
-    postMedias.forEach(postMedia -> postMedia.setPostId(postId));
-    postMediaService.save(postMedias);
+
+    List<PostMedia> newPostMedia = postMedias.stream()
+        .map(postMedia -> new PostMedia(postMedia.getType(), postMedia.getUrl(), postId))
+        .collect(Collectors.toList());
+
+    postMediaService.save(newPostMedia);
   }
 }

--- a/src/main/java/com/mindDiary/mindDiary/service/PostServiceImpl.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/PostServiceImpl.java
@@ -3,9 +3,11 @@ package com.mindDiary.mindDiary.service;
 import com.mindDiary.mindDiary.entity.PageCriteria;
 import com.mindDiary.mindDiary.entity.Post;
 import com.mindDiary.mindDiary.entity.PostMedia;
+import com.mindDiary.mindDiary.entity.PostTag;
 import com.mindDiary.mindDiary.entity.Tag;
 import com.mindDiary.mindDiary.repository.PostRepository;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -41,28 +43,18 @@ public class PostServiceImpl implements PostService {
     return postRepository.findById(postId);
   }
 
-
-  private void createPostTag(Tag tag, int postId) {
-      Tag findTag = tagService.findByName(tag.getName());
-
-      if (findTag != null) {
-        postTagService.save(postId, findTag.getId());
-        return;
-      }
-
-      tagService.save(tag);
-      postTagService.save(postId, tag.getId());
-  }
-
   private void createPostTags(List<Tag> tags, int postId) {
-    if (tags.isEmpty()) {
-      return;
-    }
 
-    for (Tag tag : tags) {
-      createPostTag(tag, postId);
-    }
+    tagService.save(tags);
+
+    List<PostTag> postTags = tags.stream()
+        .map(tag -> new PostTag(postId, tag.getId()))
+        .collect(Collectors.toList());
+
+    postTagService.save(postTags);
+
   }
+
 
   private void createPostMedias(List<PostMedia> postMedias, int postId) {
     if (postMedias.isEmpty()) {

--- a/src/main/java/com/mindDiary/mindDiary/service/PostTagService.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/PostTagService.java
@@ -1,6 +1,9 @@
 package com.mindDiary.mindDiary.service;
 
+import com.mindDiary.mindDiary.entity.PostTag;
+import java.util.List;
+
 public interface PostTagService {
 
-  void save(int postId, int tagId);
+  void save(List<PostTag> postTags);
 }

--- a/src/main/java/com/mindDiary/mindDiary/service/PostTagServiceImpl.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/PostTagServiceImpl.java
@@ -1,6 +1,8 @@
 package com.mindDiary.mindDiary.service;
 
+import com.mindDiary.mindDiary.entity.PostTag;
 import com.mindDiary.mindDiary.repository.PostTagRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,7 +15,7 @@ public class PostTagServiceImpl implements PostTagService {
   private final PostTagRepository postTagRepository;
 
   @Override
-  public void save(int postId, int tagId) {
-    postTagRepository.save(postId, tagId);
+  public void save(List<PostTag> postTags) {
+    postTagRepository.save(postTags);
   }
 }

--- a/src/main/java/com/mindDiary/mindDiary/service/TagService.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/TagService.java
@@ -1,10 +1,11 @@
 package com.mindDiary.mindDiary.service;
 
 import com.mindDiary.mindDiary.entity.Tag;
+import java.util.List;
 
 public interface TagService {
 
-  void save(Tag tag);
-
   Tag findByName(String name);
+
+  void save(List<Tag> tags);
 }

--- a/src/main/java/com/mindDiary/mindDiary/service/TagServiceImpl.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/TagServiceImpl.java
@@ -3,6 +3,7 @@ package com.mindDiary.mindDiary.service;
 
 import com.mindDiary.mindDiary.entity.Tag;
 import com.mindDiary.mindDiary.repository.TagRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -15,12 +16,12 @@ public class TagServiceImpl implements TagService {
   private final TagRepository tagRepository;
 
   @Override
-  public void save(Tag tag) {
-    tagRepository.save(tag);
+  public Tag findByName(String name) {
+    return tagRepository.findByName(name);
   }
 
   @Override
-  public Tag findByName(String name) {
-    return tagRepository.findByName(name);
+  public void save(List<Tag> tags) {
+    tagRepository.save(tags);
   }
 }

--- a/src/main/java/com/mindDiary/mindDiary/service/UserDiagnosisServiceImpl.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/UserDiagnosisServiceImpl.java
@@ -1,9 +1,7 @@
 package com.mindDiary.mindDiary.service;
 
-import com.mindDiary.mindDiary.dto.response.ReadDiagnosisResultResponseDTO;
 import com.mindDiary.mindDiary.entity.UserDiagnosis;
 import com.mindDiary.mindDiary.repository.UserDiagnosisRepository;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/mindDiary/mindDiary/service/UserServiceImpl.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/UserServiceImpl.java
@@ -2,7 +2,6 @@ package com.mindDiary.mindDiary.service;
 
 import com.mindDiary.mindDiary.entity.Token;
 import com.mindDiary.mindDiary.entity.User;
-import com.mindDiary.mindDiary.exception.businessException.BusinessException;
 import com.mindDiary.mindDiary.exception.businessException.EmailDuplicatedException;
 import com.mindDiary.mindDiary.exception.businessException.NicknameDuplicatedException;
 import com.mindDiary.mindDiary.exception.businessException.InvalidEmailTokenException;
@@ -14,7 +13,6 @@ import com.mindDiary.mindDiary.strategy.jwt.TokenStrategy;
 import com.mindDiary.mindDiary.strategy.redis.RedisStrategy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.ibatis.javassist.NotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/mindDiary/mindDiary/service/UserServiceImpl.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/UserServiceImpl.java
@@ -60,6 +60,7 @@ public class UserServiceImpl implements UserService {
   public void checkEmailToken(String token, String email) {
 
     User user = userRepository.findByEmail(email);
+    log.info(user.toString());
 
     isValidateUserIdInCache(user.getId(), token);
 

--- a/src/main/java/com/mindDiary/mindDiary/service/UserTransactionService.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/UserTransactionService.java
@@ -1,0 +1,5 @@
+package com.mindDiary.mindDiary.service;
+
+public interface UserTransactionService {
+  void removeCacheAfterRollback(String emailToken);
+}

--- a/src/main/java/com/mindDiary/mindDiary/service/UserTransactionServiceImpl.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/UserTransactionServiceImpl.java
@@ -1,0 +1,31 @@
+package com.mindDiary.mindDiary.service;
+
+import com.mindDiary.mindDiary.strategy.redis.RedisStrategy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserTransactionServiceImpl implements UserTransactionService {
+
+  private final RedisStrategy redisStrategy;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void removeCacheAfterRollback(String emailToken) {
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCompletion(int status) {
+            if (status == STATUS_ROLLED_BACK) {
+              redisStrategy.deleteValue(emailToken);
+            }
+          }
+        });
+  }
+}

--- a/src/main/resources/mapper/diagnosis.xml
+++ b/src/main/resources/mapper/diagnosis.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.mindDiary.mindDiary.repository.DiagnosisRepository">
 
-  <select id = "findDiagnosis" resultType="com.mindDiary.mindDiary.entity.Diagnosis">
+  <select id = "findDiagnoses" resultType="com.mindDiary.mindDiary.entity.Diagnosis">
     SELECT id, name, number_of_choice
     FROM diagnosis
   </select>

--- a/src/main/resources/mapper/diary.xml
+++ b/src/main/resources/mapper/diary.xml
@@ -8,13 +8,13 @@
   </update>
 
   <select id = "findById" parameterType="int" resultType="com.mindDiary.mindDiary.entity.Diary">
-    SELECT created_at, feeling_status, title, content
+    SELECT id, user_id, created_at, feeling_status, title, content
     FROM diary
     WHERE id = #{diaryId}
   </select>
 
   <select id = "findByUserId" parameterType="int" resultType="com.mindDiary.mindDiary.entity.Diary">
-    SELECT id, created_at, feeling_status, title
+    SELECT id, user_id, created_at, feeling_status, title
     FROM diary
     WHERE user_id = #{userId}
   </select>

--- a/src/main/resources/mapper/postTag.xml
+++ b/src/main/resources/mapper/postTag.xml
@@ -2,9 +2,11 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.mindDiary.mindDiary.repository.PostTagRepository">
 
-  <update id="save" parameterType="int">
-    INSERT INTO post_tag (post_id, tag_id)
-    VALUES(#{postId}, #{tagId})
+ <update id="save" parameterType="java.util.List">
+   INSERT INTO post_tag (post_id, tag_id)
+    VALUES
+        <foreach collection="list" item="item" separator=",">
+          (#{item.postId}, #{item.tagId})
+        </foreach>
   </update>
-
 </mapper>

--- a/src/main/resources/mapper/tag.xml
+++ b/src/main/resources/mapper/tag.xml
@@ -2,11 +2,16 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.mindDiary.mindDiary.repository.TagRepository">
 
-  <update id="save" useGeneratedKeys="true" keyProperty="id" parameterType="com.mindDiary.mindDiary.entity.Tag">
-    INSERT INTO tag(name)
-    VALUES(#{name})
-  </update>
   <select id = "findByName" parameterType="String" resultType="com.mindDiary.mindDiary.entity.Tag">
     SELECT * FROM tag WHERE name = #{name}
   </select>
+
+  <update id="save" useGeneratedKeys="true" keyProperty="id" parameterType="java.util.List">
+    INSERT INTO tag(name)
+    VALUES
+    <foreach collection="list" item="item" separator=",">
+      (#{item.name})
+    </foreach>
+  </update>
+
 </mapper>

--- a/src/main/resources/mapper/user.xml
+++ b/src/main/resources/mapper/user.xml
@@ -8,11 +8,11 @@
   </update>
 
   <select id = "findByEmail" parameterType="String" resultType="com.mindDiary.mindDiary.entity.User">
-    SELECT * FROM user WHERE email = #{email}
+    SELECT id, email, nickname, password, role FROM user WHERE email = #{email}
   </select>
 
   <select id = "findByNickname" parameterType="String" resultType="com.mindDiary.mindDiary.entity.User">
-    SELECT * FROM user WHERE nickname = #{nickname}
+    SELECT id, email, nickname, password, role FROM user WHERE nickname = #{nickname}
   </select>
 
   <update id = "updateRole" parameterType="com.mindDiary.mindDiary.entity.User">
@@ -22,7 +22,7 @@
   </update>
 
   <select id = "findById" parameterType="int" resultType="com.mindDiary.mindDiary.entity.User">
-    SELECT * FROM user WHERE id = #{id}
+    SELECT id, email, nickname, password, role FROM user WHERE id = #{id}
   </select>
 
 </mapper>

--- a/src/test/java/com/mindDiary/mindDiary/service/user/LoginTest.java
+++ b/src/test/java/com/mindDiary/mindDiary/service/user/LoginTest.java
@@ -58,9 +58,7 @@ public class LoginTest {
   RedisStrategy redisStrategy;
 
   public static Token createToken() {
-    Token token = new Token();
-    token.setAccessToken(ACCESS_TOKEN);
-    token.setRefreshToken(REFRESH_TOKEN);
+    Token token = new Token(ACCESS_TOKEN, REFRESH_TOKEN);
     return token;
   }
 


### PR DESCRIPTION
- 피드백 반영 (API 이름 수정)

- 트랜잭션 config 설정

- 클래스의 setter 삭제 
setter를 제거하고, 생성자로만 객체를 생성하도록 수정했습니다. 
외부 클래스에서 이곳 저곳 사용되던 setter를 막음으로써 의도치 않은 데이터 변경과 같은 side effect를 줄이려 했습니다. 
이전과 로직은 동일한데, setter를 없애다보니 코드 수정이 많아졌네요.

