### PR TITLE
[ Feature/35 ]  게시글 작성, 조회, 회원가입 트랜잭션 적용

### DIFF
--- a/src/main/java/com/mindDiary/mindDiary/service/UserServiceImpl.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/UserServiceImpl.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -29,6 +30,7 @@ public class UserServiceImpl implements UserService {
   private final RedisStrategy redisStrategy;
   private final EmailStrategy emailStrategy;
   private final TokenStrategy tokenStrategy;
+  private final UserTransactionService userTransactionService;
 
 
   @Override
@@ -45,21 +47,9 @@ public class UserServiceImpl implements UserService {
     redisStrategy.addEmailToken(user.getEmailCheckToken(), user.getId());
     emailStrategy.sendUserJoinMessage(user.getEmailCheckToken(), user.getEmail());
 
-    removeCacheAfterRollback(user.getEmailCheckToken());
+    userTransactionService.removeCacheAfterRollback(user.getEmailCheckToken());
   }
 
-
-  public void removeCacheAfterRollback(String emailToken) {
-    TransactionSynchronizationManager.registerSynchronization(
-        new TransactionSynchronization() {
-          @Override
-          public void afterCompletion(int status) {
-            if (status == STATUS_ROLLED_BACK) {
-              redisStrategy.deleteValue(emailToken);
-            }
-          }
-        });
-  }
 
 
   public void isNicknameDuplicate(String nickname) {

--- a/src/main/java/com/mindDiary/mindDiary/service/UserTransactionService.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/UserTransactionService.java
@@ -1,0 +1,5 @@
+package com.mindDiary.mindDiary.service;
+
+public interface UserTransactionService {
+  void removeCacheAfterRollback(String emailToken);
+}

--- a/src/main/java/com/mindDiary/mindDiary/service/UserTransactionServiceImpl.java
+++ b/src/main/java/com/mindDiary/mindDiary/service/UserTransactionServiceImpl.java
@@ -1,0 +1,31 @@
+package com.mindDiary.mindDiary.service;
+
+import com.mindDiary.mindDiary.strategy.redis.RedisStrategy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserTransactionServiceImpl implements UserTransactionService {
+
+  private final RedisStrategy redisStrategy;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void removeCacheAfterRollback(String emailToken) {
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCompletion(int status) {
+            if (status == STATUS_ROLLED_BACK) {
+              redisStrategy.deleteValue(emailToken);
+            }
+          }
+        });
+  }
+}


### PR DESCRIPTION
게시글 작성, 조회, 회원가입에 트랜잭션을 적용했습니다.

회원가입의 경우,
인증 메일 전송이 실패했을 때 트랜잭션 롤백이 발생하는 경우가 있을텐데요.  
그럴 경우, redis 에 넣은 이메일 토큰 값을 제거해줘야 하기 때문에 롤백이 일어났을 때 후처리를 해줘야 합니다.
그래서 토큰 값을 redis에서 제거하는 후처리 코드를 작성했습니다.

TransactionSynchronization의  afterCompletion 이라는 메서드를 사용하여 롤백 후의 처리를 합니다.

이 메서드는
 원래의 트랜잭션의 리소스를 정리하지 않은 채 메서드가 실행되서, 원래의 트랜잭션에 그대로 참여한다고 합니다. 
그래서 propagation을 required_new로 꼭 설정해서, 별도의 트랜잭션을 만들어서 추가적인 커밋이나 기능을 작성하도록 하라고 문서에 명시되어있습니다.

그리고, UserTransactionService로 클래스를 분리한 이유는
@Transactioal의 경우 프록시 방식의 AOP 를 사용하는데요. 
이 방식은 같은 타깃 클래스 내의 메소드를 직접 호출할 때에는 AOP가 적용되지 않습니다. 
(여기서는 join 메서드에서 removeCacheAfterRollback 메서드를 직접 호출해서 트랜잭션 후처리를 합니다. )

그래서, 회원가입 트랜잭션 + removeCacheAfterRollback  트랜잭션을 한 클래스에 같이 둘 경우 롤백처리 트랜잭션의 전파 속성(required_new)가 무시되고 트랜잭션 AOP가 적용되지 않습니다.

그래서 클래스를 분리해서 트랜잭션이 정상적으로 작동하도록 했습니다.